### PR TITLE
Update template to work with TeXLive 2016

### DIFF
--- a/sharifthesis.cls
+++ b/sharifthesis.cls
@@ -180,7 +180,7 @@
 
 \RequirePackage{multicol,float,array}
 % The order of package inclusions is important
-\RequirePackage[localise]{xepersian}
+\RequirePackage[localise,extrafootnotefeatures]{xepersian}
 
 \RequirePackage{url}
 %% Define a new 'leo' style for the package that will use a smaller font.


### PR DESCRIPTION
Following error will be seen by running `make` with TeXLive 2016:

```
You can't use `\relax' after \the.
<recently read> \c@zabspage
```

Reason is that

> new version of zref-abspage breaks the bidi package

as mentioned in [this issue](https://github.com/ho-tex/oberdiek/issues/4)

This solution is taken from [here](http://qa.parsilatex.com/19359/%D8%AE%D8%B7%D8%A7-%D8%AF%D8%B1-%D8%B2%DB%8C%D8%B1%D9%86%D9%88%DB%8C%D8%B3-%D8%AF%D8%B1-%D8%AA%DA%A9-%D9%84%D8%A7%DB%8C%D9%88-%DB%B2%DB%B0%DB%B1%DB%B6)
