### PR TITLE
Drive the build with latexmk, and add CI

### DIFF
--- a/.github/ci/stand-in-fonts.py
+++ b/.github/ci/stand-in-fonts.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Present a freely licensed font under the names the class asks for.
+
+sharifthesis.cls requests XBZar, Yas and IranNastaliq. Those are not free and are
+not in TeX Live, so they cannot be committed here or installed on a CI runner.
+XeTeX resolves fonts by their internal family name, so this takes a font that IS
+in TeX Live and writes copies of it whose name table reports the wanted names.
+
+This exists only so CI can prove the template still compiles. The result is not
+what a thesis should look like; build locally with the real fonts for that.
+"""
+import struct, sys, os
+
+def read_table_dir(d):
+    num = struct.unpack(">H", d[4:6])[0]
+    for i in range(num):
+        e = 12 + 16 * i
+        yield e, bytes(d[e:e + 4])
+
+def build_name_table(family, subfamily="Regular"):
+    """A fresh name table carrying just the identifying records."""
+    records, storage = [], b""
+    for platform, encoding, language, encode in (
+        (3, 1, 0x409, lambda s: s.encode("utf-16-be")),   # Windows
+        (1, 0, 0,     lambda s: s.encode("latin-1")),     # Macintosh
+    ):
+        for name_id, value in ((1, family), (2, subfamily),
+                               (4, family), (6, family.replace(" ", ""))):
+            data = encode(value)
+            records.append((platform, encoding, language, name_id,
+                            len(data), len(storage)))
+            storage += data
+    records.sort(key=lambda r: (r[0], r[1], r[2], r[3]))
+    offset = 6 + 12 * len(records)
+    out = struct.pack(">HHH", 0, len(records), offset)
+    for r in records:
+        out += struct.pack(">HHHHHH", *r)
+    return out + storage
+
+def rename(src, dst, family, subfamily="Regular"):
+    d = bytearray(open(src, "rb").read())
+    table = build_name_table(family, subfamily)
+    while len(d) % 4:                      # tables must be 4-byte aligned
+        d += b"\0"
+    offset = len(d)
+    d += table
+    for entry, tag in read_table_dir(d):
+        if tag == b"name":
+            struct.pack_into(">II", d, entry + 8, offset, len(table))
+            break
+    else:
+        raise SystemExit("%s: no name table" % src)
+    open(dst, "wb").write(bytes(d))
+
+if __name__ == "__main__":
+    src, outdir = sys.argv[1], sys.argv[2]
+    os.makedirs(outdir, exist_ok=True)
+    for family in ("XBZar", "Yas", "IranNastaliq"):
+        rename(src, os.path.join(outdir, family + ".ttf"), family)
+        print("  %s.ttf" % family)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  # Pinned, and expected to pass. This is the version the template was last
+  # adjusted for.
+  build:
+    runs-on: ubuntu-latest
+    container: texlive/texlive:TL2025-historic
+    steps:
+      - uses: actions/checkout@v4
+
+      # XBZar, Yas and IranNastaliq are not free and cannot be installed here, so
+      # a font that ships with TeX Live is presented under those names. This is
+      # enough to prove the document still compiles; it is not what it looks like.
+      - name: Stand-in fonts
+        run: |
+          amiri=$(fc-list | grep -m1 Amiri-Regular.ttf | cut -d: -f1)
+          python3 .github/ci/stand-in-fonts.py "$amiri" /usr/local/share/fonts/standin
+          fc-cache -f
+
+      - name: Build
+        run: make
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: main.pdf
+          path: main.pdf
+
+  # Unpinned, and allowed to fail. This is the early warning: when a new TeX Live
+  # breaks the template, this job says so before a student reports it.
+  latest:
+    runs-on: ubuntu-latest
+    container: texlive/texlive:latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stand-in fonts
+        run: |
+          amiri=$(fc-list | grep -m1 Amiri-Regular.ttf | cut -d: -f1)
+          python3 .github/ci/stand-in-fonts.py "$amiri" /usr/local/share/fonts/standin
+          fc-cache -f
+      - name: Build
+        run: make

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 *.glsdefs
 *.run.xml
 *~
+*.xdv

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,0 +1,35 @@
+# latexmk configuration for the Sharif thesis template.
+#
+# latexmk works the same on Linux, macOS, Windows and Overleaf, and decides for
+# itself how many times each tool has to run. The Makefile calls it, so both ways
+# of building stay available.
+
+$pdf_mode = 5;    # xelatex
+
+# Keep the flags the Makefile has always used, including the PDF minor version.
+$xelatex = 'xelatex -halt-on-error -shell-escape -interaction=nonstopmode '
+         . '-synctex=-1 -output-driver="xdvipdfmx -E -V 5" %O %S';
+
+$bibtex_use = 2;  # biber, via biblatex
+
+# The glossaries are sorted by xindy, which latexmk knows nothing about. The two
+# glossary files are main.fa.glo and main.en.glo, so latexmk sees the base names
+# "main.fa" and "main.en" and the language is taken from that suffix.
+# variant1-utf8 sorts آ and ا together.
+add_cus_dep('glo', 'gls', 0, 'run_xindy');
+
+sub run_xindy {
+    my ($base) = @_;
+    my ($doc, $lang) = ($base, 'english');
+    my $codepage = 'utf8';
+    if ($base =~ /^(.*)\.fa$/) { $doc = $1; $lang = 'persian'; $codepage = 'variant1-utf8'; }
+    elsif ($base =~ /^(.*)\.en$/) { $doc = $1; }
+    return system('xindy', '--language', $lang, '--codepage', $codepage,
+                  '--input-markup', 'xindy', '--module', $doc,
+                  '--log-file', "$base.glg", '--out-file', "$base.gls",
+                  "$base.glo");
+}
+
+# Files the tools above leave behind.
+$clean_ext = 'fa.glo fa.gls fa.glg en.glo en.gls en.glg glsdefs '
+           . 'run.xml bbl synctex.gz xdy';

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SRC=main
 TEX=xelatex
 BIB=biber
 XINDY=xindy
+LATEXMK=latexmk
 
 # Output PDF minor version
 PDFMINORVER=5
@@ -42,19 +43,12 @@ all: $(SRC).pdf
 img/%.pdf img/%.pdf_tex: img/%.svg
 	inkscape --export-area-drawing --without-gui --file=$< --export-pdf=$@ --export-latex
 
-# Build the main file
-$(SRC).pdf: $(SRC).tex $(TEX0) $(BIB0) $(SVG0) $(SVGOUT) Makefile
-	rm -fv $(SRC).pdf $(SRC).bbl *.gls *.glo
-	$(TEX) $(TEXOPTIONS) $<
-	$(BIB) $(SRC)
-	#$(XINDY) -L persian -C utf8 -I xindy -M $(SRC) -t $(SRC).glg -o $(SRC).gls $(SRC).glo
-	# variant1: Sorts آ and ا together, variant2: Separates them.
-	$(XINDY) --language persian --codepage variant1-utf8 --input-markup xindy --module $(SRC) --log-file $(SRC).fa.glg --out-file $(SRC).fa.gls $(SRC).fa.glo
-	$(XINDY) --language english --codepage utf8 --input-markup xindy --module $(SRC) --log-file $(SRC).en.glg --out-file $(SRC).en.gls $(SRC).en.glo
-	#makeglossaries $(SRC)
-	$(TEX) $(TEXOPTIONS) $<
-	while grep --fixed-strings "Rerun to" $(SRC).log || grep --fixed-strings "Please rerun LaTeX" $(SRC).log ; do $(TEX) $(TEXOPTIONS) $< ; done
-	$(TEX) $(TEXOPTIONS) $<
+# Build the main file.
+# latexmk runs xelatex, biber and xindy as often as the document needs, using the
+# settings in .latexmkrc. It works the same on Windows and on Overleaf, where the
+# loop below and the xindy invocations did not.
+$(SRC).pdf: $(SRC).tex $(TEX0) $(BIB0) $(SVG0) $(SVGOUT) Makefile .latexmkrc
+	$(LATEXMK) $(SRC).tex
 	@echo -e "===========================\nWarnings:\n"
 	@grep 'Warning\|Error\|Underful\|Overful' $(SRC).log | sort
 
@@ -70,6 +64,7 @@ markdown: TODO.markdown
 cleanall: clean cleansvg cleanfig
 
 clean:
+	-$(LATEXMK) -C
 	rm -fv $(SRC).pdf *.log *.aux *.auxlock *.bbl *.bcf *.glsdefs *.run.xml *.blg *.out *.dvi *.synctex *.toc *.lof *.lot *.maf *.mtc* *.glg *.glo *.gls $(SRC).xdy *~ images/*~ $(SRC)-gnuplottex-fig* *.dep *.dpth $(SRC)-figure*.xdy */*.aux
 
 cleansvg:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The template is organized as follows:
 ## Compilation
 For compiling TeX files to PDF, issue **make** command. It compiles biber (a biblatex engine) for references, xindy for two glossaries, and XeLaTeX for the PDF file itself. It compiles as many times as required to get all cross-links correctly compiled. For sake of fast compilation, you can use **make once** which just runs XeLaTeX once. While the thesis is not finalized, it's not important to always have an updated glossary or references list. So you can **make once** by default and **make** to obtain the final version. By the way, you need to **make** for the first time. Because with empty glossaries, **make once** won't succeed. Also you should add name of all TeX files to the *TEX0* variable in the Makefile.
 
+The **make** command drives *latexmk*, configured in *.latexmkrc*, which decides how many times XeLaTeX, biber and xindy have to run. You can also call **latexmk** directly, which is useful on Windows and on Overleaf, where the Makefile is not available. Both routes produce the same PDF.
+
 ## License
     Copyright © 2013-2026 Behnam Momeni
 


### PR DESCRIPTION
The build rule had a hand-written rerun loop and two hardcoded xindy calls. latexmk works
out how many passes are needed, so it collapses to one line:

```diff
-	rm -fv $(SRC).pdf $(SRC).bbl *.gls *.glo
-	$(TEX) $(TEXOPTIONS) $<
-	$(BIB) $(SRC)
-	$(XINDY) --language persian --codepage variant1-utf8 ... $(SRC).fa.glo
-	$(XINDY) --language english --codepage utf8 ... $(SRC).en.glo
-	$(TEX) $(TEXOPTIONS) $<
-	while grep --fixed-strings "Rerun to" $(SRC).log ... ; do $(TEX) $(TEXOPTIONS) $< ; done
-	$(TEX) $(TEXOPTIONS) $<
+	$(LATEXMK) $(SRC).tex
```

The glossary rules live in `.latexmkrc` now. The files are `main.fa.glo` and
`main.en.glo`, so latexmk reads the base as `main.fa` and `main.en`, and the language has to
come off that suffix. `variant1-utf8` stays, so آ and ا sort together as before.

Output is unchanged: 32 pages from a clean tree, glossary still استانده، بسته، پرونده، پوشه،
داده‌ساختار، سامانه‌ی پایش نسخه‌ها، سامانه‌ی عامل، قالب.

`make` is unchanged for anyone using it. Windows and Overleaf users can now run `latexmk`
directly, which is also part of #7.

Fonts blocked the CI part. XBZar, Yas and IranNastaliq are not free and cannot go on a
runner, but XeTeX matches on the internal family name, so `ci/stand-in-fonts.py` rewrites
Amiri's name table to claim all three. It checks compilation only; the PDF it produces is
not a real thesis.

Pinned job: `TL2025-historic`, 32 pages, no real fonts needed.

The unpinned job is red. TeX Live 2026 does not build this template at all. `bidi`'s
`array-xetex-bidi.def` calls `\UseMathForPositioningText`, which is gone, and every
`tabular` kills the run. Filed as persiantex/bidi#24. I added the job because 2025 broke
the template too and it was a user who found out. If you would rather not stare at a red
badge until bidi is fixed, drop that job and keep the pinned one.
